### PR TITLE
【投稿お気に入り機能】お気に入りの投稿取得時にその投稿者の情報も取得できるよう変更

### DIFF
--- a/controllers/user-controller.js
+++ b/controllers/user-controller.js
@@ -1,7 +1,16 @@
 const db = require('../models/index');
 const bcrypt = require('bcrypt');
 
-const favoritePostsAssociation = { model: db.post, as: 'favoritePosts' };
+const userAttributes = ['id', 'username', 'icon_url'];
+
+const favoritePostsAssociation = { 
+  model: db.post, 
+  as: 'favoritePosts', // お気に入りの投稿一覧のフィールド名
+  include: { // お気に入りの投稿の投稿者の情報も取得
+    model: db.user , 
+    attributes: userAttributes 
+  }, 
+};
 
 const userController = {
   // ユーザー一覧取得


### PR DESCRIPTION
## Issue
#26 

## 内容
- controllers/user-controller.jsのfavoritePostsAssociationにinclude属性を追加し、お気に入りの投稿からその投稿者の情報を参照できるように変更