### PR TITLE
【ユーザー機能】ユーザーがいいねした回答一覧を取得する機能を追加

### DIFF
--- a/controllers/user-controller.js
+++ b/controllers/user-controller.js
@@ -3,7 +3,7 @@ const bcryptjs = require("bcryptjs");
 
 const userAttributes = ["id", "username", "icon_url", "self_introduction"];
 const postAttributes = ["id", "title", "property"];
-const answerAttributes = ["id", "content", "updatedAt"];
+const answerAttributes = ["id", "content", "createdAt", "updatedAt"];
 
 const userController = {
   // ユーザー一覧取得
@@ -25,15 +25,29 @@ const userController = {
     db.user
       .findByPk(req.params.userId, {
         attributes: userAttributes,
-        include: {
-          model: db.answer, // ユーザーの回答一覧
-          attributes: answerAttributes,
-          include: {
-            model: db.post, // 回答の対象となる投稿
-            attributes: postAttributes,
+        include: [
+          {
+            model: db.answer, // ユーザーの回答一覧
+            attributes: answerAttributes,
+            include: {
+              model: db.post, // 回答の対象となる投稿
+              attributes: postAttributes,
+            },
           },
-        },
-        order: [[db.answer, "updatedAt", "DESC"]],
+          {
+            model: db.answer,
+            attriubtes: answerAttributes,
+            as: "likedAnswer",
+            include: {
+              model: db.post,
+              attributes: postAttributes,
+            },
+          },
+        ],
+        order: [
+          [db.answer, "createdAt", "DESC"],
+          ["likedAnswer", "createdAt", "DESC"],
+        ],
       })
       .then((user) => {
         if (!user) {


### PR DESCRIPTION
## Issue
#87 

## 概要
ユーザーがいいねした回答の一覧をユーザーのデータと一緒に取得できるように仕様を変更

以下詳細
- ユーザー詳細取得ミドルウェアのincludeにlikedAnswerアソシエーションを追加
- ユーザー詳細取得ミドルウェアの回答のattributesにcreatedAtを追加
- 上記のテストを追加

## 動作確認内容
テストを実行してすべて成功することを確認

![image](https://user-images.githubusercontent.com/83702606/139680033-980f512e-a3c4-4d0c-85b8-3107d48fbdc5.png)
