### PR TITLE
【回答機能】特定のユーザーがいいねした回答の一覧を取得する機能を作成

### DIFF
--- a/controllers/user-controller.js
+++ b/controllers/user-controller.js
@@ -34,19 +34,9 @@ const userController = {
               attributes: postAttributes,
             },
           },
-          {
-            model: db.answer,
-            attriubtes: answerAttributes,
-            as: "likedAnswer",
-            include: {
-              model: db.post,
-              attributes: postAttributes,
-            },
-          },
         ],
         order: [
           [db.answer, "createdAt", "DESC"],
-          ["likedAnswer", "createdAt", "DESC"],
         ],
       })
       .then((user) => {

--- a/routes/answers.js
+++ b/routes/answers.js
@@ -1,40 +1,47 @@
-const express = require('express');
+const express = require("express");
 const router = express.Router();
-const answerController = require('../controllers/answer-controller');
+const answerController = require("../controllers/answer-controller");
+
+// いいねした回答を取得
+router.get(
+  "/liked/answer/:id/:page",
+  answerController.getLikedAnswers,
+  answerController.errorHandling
+);
 
 // 回答を作成
 router.post(
-  '/create', 
-  answerController.createAnswer, 
+  "/create",
+  answerController.createAnswer,
   answerController.errorHandling
 );
 
 // 回答を更新
 router.patch(
-  '/update/:answerId', 
-  answerController.updateAnswer, 
+  "/update/:answerId",
+  answerController.updateAnswer,
   answerController.errorHandling
 );
 
 // 回答を削除
 router.delete(
-  '/destroy/:answerId', 
-  answerController.destroyAnswer, 
+  "/destroy/:answerId",
+  answerController.destroyAnswer,
   answerController.errorHandling
 );
 
 // いいねを追加
 router.post(
-  '/add/like',
+  "/add/like",
   answerController.addLikes,
-  answerController.errorHandling,
+  answerController.errorHandling
 );
 
 // いいねを解除
 router.delete(
-  '/remove/like/:answerId/user/:userId',
+  "/remove/like/:answerId/user/:userId",
   answerController.removeLikes,
-  answerController.errorHandling,
+  answerController.errorHandling
 );
 
 module.exports = router;

--- a/tests/api/answer.test.js
+++ b/tests/api/answer.test.js
@@ -6,14 +6,23 @@ const userData = [
   {
     id: "userId1",
     username: "user1",
+    icon_url: "userIcon1",
     email: "email1",
     password: "password1",
   },
   {
     id: "userId2",
     username: "user2",
+    icon_url: "userIcon2",
     email: "email2",
     password: "password2",
+  },
+  {
+    id: "userId3",
+    username: "user3",
+    icon_url: "userIcon3",
+    email: "email3",
+    password: "password3",
   },
 ];
 
@@ -26,36 +35,123 @@ const addressData = {
   buildingName: "building1",
 };
 
-const postData = {
-  id: "post1",
-  title: "title1",
-  property: "test-property1",
-  text: "text1",
-  authorId: "userId1",
-  addressId: "addressId1",
-  updatedAt: new Date(2021, 1, 1, 0, 0, 0),
-};
+const postData = [
+  {
+    id: "post1",
+    title: "title1",
+    property: "test-property1",
+    text: "text1",
+    authorId: "userId1",
+    addressId: "addressId1",
+    updatedAt: new Date(2021, 1, 1, 0, 0, 0),
+  },
+  {
+    id: "post2",
+    title: "title2",
+    property: "test-property2",
+    text: "text2",
+    authorId: "userId2",
+    addressId: "addressId1",
+    updatedAt: new Date(2021, 1, 2, 0, 0, 0),
+  },
+];
 
-const answerData = {
-  id: "answerId1",
-  content: "content1",
-  questionId: "post1",
-  respondentId: "userId2",
-};
+const answerData = [
+  {
+    id: "answerId1",
+    content: "content1",
+    questionId: "post1",
+    respondentId: "userId2",
+    createdAt: new Date(2021, 1, 10, 0, 0, 0),
+  },
+  {
+    id: "answerId2",
+    content: "content2",
+    questionId: "post2",
+    respondentId: "userId3",
+    createdAt: new Date(2021, 1, 20, 0, 0, 0),
+  },
+];
+
+const userAnswerData = [
+  {
+    answerId: "answerId1",
+    userId: "userId2",
+  },
+  {
+    answerId: "answerId2",
+    userId: "userId2",
+  },
+  {
+    answerId: "answerId2",
+    userId: "userId1",
+  },
+];
 
 describe("answerAPIのテスト", () => {
   beforeAll(async () => {
     await db.user.bulkCreate(userData);
     await db.address.create(addressData);
-    await db.post.create(postData);
-    await db.answer.create(answerData);
+    await db.post.bulkCreate(postData);
+    await db.answer.bulkCreate(answerData);
+    await db.UserAnswer.bulkCreate(userAnswerData);
   });
 
   afterAll(async () => {
+    await db.UserAnswer.destroy({ where: {} });
     await db.post.destroy({ where: {} });
     await db.address.destroy({ where: {} });
     await db.user.destroy({ where: {} });
     await db.answer.destroy({ where: {} });
+  });
+
+  describe("GET /answers/liked/answer/:userId/:page のテスト", () => {
+    describe("正常系", () => {
+      it("ユーザーがいいねした回答を正常に取得できる", async () => {
+        const response = await request(server).get(
+          "/answers/liked/answer/userId2/1"
+        );
+
+        const answer1CreatedAt = new Date(2021, 1, 10, 0, 0, 0);
+        const answer2CreatedAt = new Date(2021, 1, 20, 0, 0, 0);
+
+        expect(response.statusCode).toBe(200);
+        expect(response.body.total).toBe(1);
+        expect(response.body.answers).toHaveLength(2);
+        expect(response.body.answers[0].id).toBe("answerId2");
+        expect(response.body.answers[0].content).toBe("content2");
+        expect(response.body.answers[0].createdAt).toBe(
+          answer2CreatedAt.toISOString()
+        );
+        expect(response.body.answers[1].id).toBe("answerId1");
+        expect(response.body.answers[1].content).toBe("content1");
+        expect(response.body.answers[1].createdAt).toBe(
+          answer1CreatedAt.toISOString()
+        );
+      });
+      it("いいねした回答から投稿のデータを取得できる", async () => {
+        const response = await request(server).get(
+          "/answers/liked/answer/userId2/1"
+        );
+
+        expect(response.body.answers[0].post.id).toBe("post2");
+        expect(response.body.answers[0].post.title).toBe("title2");
+        expect(response.body.answers[1].post.id).toBe("post1");
+        expect(response.body.answers[1].post.title).toBe("title1");
+      });
+      it("いいねした回答の回答者のデータを取得できる", async () => {
+        const response = await request(server).get(
+          "/answers/liked/answer/userId2/1"
+        );
+
+        expect(response.body.answers[0].user.id).toBe("userId3");
+        expect(response.body.answers[0].user.username).toBe("user3");
+        expect(response.body.answers[0].user.icon_url).toBe("userIcon3");
+        expect(response.body.answers[1].user.id).toBe("userId2");
+        expect(response.body.answers[1].user.username).toBe("user2");
+        expect(response.body.answers[1].user.icon_url).toBe("userIcon2");
+      });
+    });
   });
 
   describe("POST /answers/create のテスト", () => {
@@ -146,10 +242,7 @@ describe("answerAPIのテスト", () => {
         const actualPostResponse = await request(server).get(
           "/posts/post/post1"
         );
-        expect(actualPostResponse.body.answers[0].likedBy).toHaveLength(1);
-        expect(actualPostResponse.body.answers[0].likedBy[0].id).toBe(
-          "userId1"
-        );
+        expect(actualPostResponse.body.answers[0].likedBy).toHaveLength(2);
       });
     });
   });
@@ -165,7 +258,10 @@ describe("answerAPIのテスト", () => {
         const actualPostResponse = await request(server).get(
           "/posts/post/post1"
         );
-        expect(actualPostResponse.body.answers[0].likedBy).toHaveLength(0);
+        expect(actualPostResponse.body.answers[0].likedBy).toHaveLength(1);
+        expect(actualPostResponse.body.answers[0].likedBy[0].id).toBe(
+          "userId2"
+        );
       });
     });
   });

--- a/tests/api/user.test.js
+++ b/tests/api/user.test.js
@@ -60,32 +60,6 @@ const answerData = [
     createdAt: new Date(2021, 2, 5, 0, 0, 0),
     updatedAt: new Date(2021, 2, 10, 0, 0, 0),
   },
-  {
-    id: "answerId3",
-    content: "answer3",
-    questionId: "postId1",
-    respondentId: "userId2",
-    createdAt: new Date(2021, 3, 5, 0, 0, 0),
-    updatedAt: new Date(2021, 3, 10, 0, 0, 0),
-  },
-  {
-    id: "answerId4",
-    content: "answer4",
-    questionId: "postId2",
-    respondentId: "userId2",
-    createdAt: new Date(2021, 4, 5, 0, 0, 0),
-    updatedAt: new Date(2021, 4, 10, 0, 0, 0),
-  },
-];
-const userAnswerData = [
-  {
-    userId: "userId1",
-    answerId: "answerId3",
-  },
-  {
-    userId: "userId1",
-    answerId: "answerId4",
-  },
 ];
 
 describe("userAPIのテスト", () => {
@@ -93,11 +67,9 @@ describe("userAPIのテスト", () => {
     await db.user.bulkCreate(userData);
     await db.post.bulkCreate(postData);
     await db.answer.bulkCreate(answerData);
-    await db.UserAnswer.bulkCreate(userAnswerData);
   });
 
   afterAll(async () => {
-    await db.UserAnswer.destroy({ where: {} });
     await db.answer.destroy({ where: {} });
     await db.post.destroy({ where: {} });
     await db.user.destroy({ where: {} });
@@ -167,50 +139,6 @@ describe("userAPIのテスト", () => {
         expect(response.body.answers[1].post.id).toBe("postId1");
         expect(response.body.answers[1].post.title).toBe("test-post1");
         expect(response.body.answers[1].post.property).toBe("test-property1");
-      });
-      it("いいねした回答の一覧を取得できる", async () => {
-        const response = await request(server).get("/users/userId1");
-
-        const answer3CreatedAt = new Date(2021, 3, 5, 0, 0, 0);
-        const answer4CreatedAt = new Date(2021, 4, 5, 0, 0, 0);
-        const answer3UpdatedAt = new Date(2021, 3, 10, 0, 0, 0);
-        const answer4UpdatedAt = new Date(2021, 4, 10, 0, 0, 0);
-
-        expect(response.body.likedAnswer).toHaveLength(2);
-        expect(response.body.likedAnswer[0].id).toBe(answerData[3].id);
-        expect(response.body.likedAnswer[0].content).toBe(
-          answerData[3].content
-        );
-        expect(response.body.likedAnswer[0].createdAt).toBe(
-          answer4CreatedAt.toISOString()
-        );
-        expect(response.body.likedAnswer[0].updatedAt).toBe(
-          answer4UpdatedAt.toISOString()
-        );
-        expect(response.body.likedAnswer[1].id).toBe(answerData[2].id);
-        expect(response.body.likedAnswer[1].content).toBe(
-          answerData[2].content
-        );
-        expect(response.body.likedAnswer[1].createdAt).toBe(
-          answer3CreatedAt.toISOString()
-        );
-        expect(response.body.likedAnswer[1].updatedAt).toBe(
-          answer3UpdatedAt.toISOString()
-        );
-      });
-      it("いいねした回答のデータから投稿のデータを取得できる", async () => {
-        const response = await request(server).get("/users/userId1");
-
-        expect(response.body.likedAnswer[0].post.id).toBe("postId2");
-        expect(response.body.likedAnswer[0].post.title).toBe("test-post2");
-        expect(response.body.likedAnswer[0].post.property).toBe(
-          "test-property2"
-        );
-        expect(response.body.likedAnswer[1].post.id).toBe("postId1");
-        expect(response.body.likedAnswer[1].post.title).toBe("test-post1");
-        expect(response.body.likedAnswer[1].post.property).toBe(
-          "test-property1"
-        );
       });
     });
     describe("異常系", () => {


### PR DESCRIPTION
## Issue
#87 

## 概要
ユーザーのデータからいいねした回答一覧を取得する機能を実装したが、ページネーション機能を追加したかったのでユーザー側の機能は削除し、いいねした回答一覧を取得する機能を新しく作成した

以下詳細
- ユーザー取得ミドルウェアのいいねした回答取得機能を削除
- 上記に伴いユーザーのテストの該当部分を削除
- ユーザーのいいねした回答一覧を取得するミドルウェアとルートを作成
- 上記のテストを作成

## 動作確認内容
テストを実行して全ケース成功することを確認

![image](https://user-images.githubusercontent.com/83702606/139954716-8a1ab42c-6895-44d7-9255-262114e0378c.png)

