### PR TITLE
【投稿機能】お気に入りに登録した投稿のidのリストを取得する機能を作成

### DIFF
--- a/controllers/post-controller.js
+++ b/controllers/post-controller.js
@@ -177,6 +177,23 @@ const postController = {
         next(err);
       });
   },
+  // お気に入りの投稿のidのリストを取得
+  getFavoritePostIdList(req, res, next) {
+    const fpa = { ...favoritePostsAssociation };
+    fpa.where = { id: req.params.userId };
+    db.post
+      .findAll({
+        include: [fpa],
+        attributes: ["id", "createdAt"],
+        order: [["createdAt", "DESC"]],
+      })
+      .then((result) => {
+        res.json(result);
+      })
+      .catch((err) => {
+        next(err);
+      });
+  },
   // 特定の投稿を取得
   getPost(req, res, next) {
     db.post

--- a/routes/posts.js
+++ b/routes/posts.js
@@ -23,6 +23,20 @@ router.post(
   postController.errorHandling
 );
 
+// お気に入りの投稿一覧取得
+router.get(
+  "/favorite/user/:userId/page/:page",
+  postController.getFavoritePosts,
+  postController.errorHandling
+);
+
+// お気に入りの投稿のidのリストを取得
+router.get(
+  "/favorite/user/:userId/id/list",
+  postController.getFavoritePostIdList,
+  postController.errorHandling
+);
+
 // 特定の投稿を取得
 router.get(
   "/post/:postId",
@@ -91,11 +105,6 @@ router.get(
   "/search/query/page/:page",
   postController.searchPosts,
   postController.errorHandling
-);
-
-router.get(
-  "/favorite/user/:userId/page/:page",
-  postController.getFavoritePosts
 );
 
 module.exports = router;

--- a/tests/api/post.test.js
+++ b/tests/api/post.test.js
@@ -1198,4 +1198,19 @@ describe("postAPIのテスト", () => {
       });
     });
   });
+
+  describe("GET /posts/favorite/user/:userId/id/list のテスト", () => {
+    describe("正常系", () => {
+      it("お気に入りの投稿のidのリストを正常に取得できる", async () => {
+        const response = await request(server).get(
+          "/posts/favorite/user/userId2/id/list"
+        );
+
+        expect(response.statusCode).toBe(200);
+        expect(response.body).toHaveLength(2);
+        expect(response.body[0].id).toBe("postId12");
+        expect(response.body[1].id).toBe("postId11");
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Issue
#93 

## 概要
お気に入りに登録した投稿のidのリストを取得するための機能を作成

以下詳細
- お気に入りに登録した投稿のidのリスト取得用ミドルウェアを作成
- お気に入りに登録した投稿のidのリスト取得用ミドルウェアのルートを作成
- 上記のテストを作成

## 動作確認内容
テストを実行して成功することを確認

![image](https://user-images.githubusercontent.com/83702606/140301531-33b135f1-9883-45a7-b48b-d7e3528e6a96.png)

