### PR TITLE
【回答機能】回答モデルに物件の評価用カラムであるevaluationを追加

### DIFF
--- a/controllers/answer-controller.js
+++ b/controllers/answer-controller.js
@@ -1,7 +1,7 @@
 const db = require("../models/index");
 
 const perPage = 10;
-const attributes = ["id", "content", "createdAt"];
+const attributes = ["id", "content", "evaluation", "createdAt"];
 const postAssociation = {
   // 投稿
   model: db.post,

--- a/controllers/post-controller.js
+++ b/controllers/post-controller.js
@@ -11,7 +11,13 @@ const attributes = [
   "createdAt",
 ];
 const userAttributes = ["id", "username", "icon_url"];
-const answerAttributes = ["id", "content", "createdAt", "updatedAt"];
+const answerAttributes = [
+  "id",
+  "content",
+  "evaluation",
+  "createdAt",
+  "updatedAt",
+];
 const addressAttributes = [
   "postalCode",
   "prefecture",

--- a/controllers/user-controller.js
+++ b/controllers/user-controller.js
@@ -3,7 +3,13 @@ const bcryptjs = require("bcryptjs");
 
 const userAttributes = ["id", "username", "icon_url", "self_introduction"];
 const postAttributes = ["id", "title", "property"];
-const answerAttributes = ["id", "content", "createdAt", "updatedAt"];
+const answerAttributes = [
+  "id",
+  "content",
+  "evaluation",
+  "createdAt",
+  "updatedAt",
+];
 
 const perPage = 15;
 

--- a/migrations/20211111114444-add-answer-column.js
+++ b/migrations/20211111114444-add-answer-column.js
@@ -1,0 +1,14 @@
+"use strict";
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    return queryInterface.addColumn("answers", "evaluation", {
+      type: Sequelize.INTEGER,
+      after: "content",
+      allowNull: false,
+      defaultValue: 0,
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {},
+};

--- a/models/answer.js
+++ b/models/answer.js
@@ -42,6 +42,11 @@ module.exports = (sequelize, DataTypes) => {
         type: DataTypes.STRING,
         allowNull: false,
       },
+      evaluation: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        defaultValue: 0,
+      },
       questionId: {
         type: DataTypes.UUID,
         allowNull: false,

--- a/tests/api/answer.test.js
+++ b/tests/api/answer.test.js
@@ -60,6 +60,7 @@ const answerData = [
   {
     id: "answerId1",
     content: "content1",
+    evaluation: 0,
     questionId: "post1",
     respondentId: "userId2",
     createdAt: new Date(2021, 1, 10, 0, 0, 0),
@@ -67,6 +68,7 @@ const answerData = [
   {
     id: "answerId2",
     content: "content2",
+    evaluation: 1,
     questionId: "post2",
     respondentId: "userId3",
     createdAt: new Date(2021, 1, 20, 0, 0, 0),
@@ -74,6 +76,7 @@ const answerData = [
   {
     id: "answerId3",
     content: "content3",
+    evaluation: 2,
     questionId: "post2",
     respondentId: "userId2",
     createdAt: new Date(2021, 1, 30, 0, 0, 0),
@@ -135,16 +138,19 @@ describe("answerAPIのテスト", () => {
 
         expect(user2Response.body.answers[0].id).toBe("answerId3");
         expect(user2Response.body.answers[0].content).toBe("content3");
+        expect(user2Response.body.answers[0].evaluation).toBe(2);
         expect(user2Response.body.answers[0].createdAt).toBe(
           answer3CreatedAt.toISOString()
         );
         expect(user2Response.body.answers[1].id).toBe("answerId1");
         expect(user2Response.body.answers[1].content).toBe("content1");
+        expect(user2Response.body.answers[1].evaluation).toBe(0);
         expect(user2Response.body.answers[1].createdAt).toBe(
           answer1CreatedAt.toISOString()
         );
         expect(user3Response.body.answers[0].id).toBe("answerId2");
         expect(user3Response.body.answers[0].content).toBe("content2");
+        expect(user3Response.body.answers[0].evaluation).toBe(1);
         expect(user3Response.body.answers[0].createdAt).toBe(
           answer2CreatedAt.toISOString()
         );
@@ -182,11 +188,13 @@ describe("answerAPIのテスト", () => {
         expect(response.body.answers).toHaveLength(2);
         expect(response.body.answers[0].id).toBe("answerId2");
         expect(response.body.answers[0].content).toBe("content2");
+        expect(response.body.answers[0].evaluation).toBe(1);
         expect(response.body.answers[0].createdAt).toBe(
           answer2CreatedAt.toISOString()
         );
         expect(response.body.answers[1].id).toBe("answerId1");
         expect(response.body.answers[1].content).toBe("content1");
+        expect(response.body.answers[1].evaluation).toBe(0);
         expect(response.body.answers[1].createdAt).toBe(
           answer1CreatedAt.toISOString()
         );
@@ -222,6 +230,7 @@ describe("answerAPIのテスト", () => {
         const params = {
           id: "createAnswerId",
           content: "createAnswer",
+          evaluation: 2,
           questionId: "post1",
           respondentId: "userId1",
         };
@@ -236,6 +245,7 @@ describe("answerAPIのテスト", () => {
         expect(answerData).toHaveLength(1);
         expect(answerData[0].id).toBe("createAnswerId");
         expect(answerData[0].content).toBe("createAnswer");
+        expect(answerData[0].evaluation).toBe(2);
         expect(answerData[0].questionId).toBe("post1");
         expect(answerData[0].respondentId).toBe("userId1");
       });

--- a/tests/api/comment.test.js
+++ b/tests/api/comment.test.js
@@ -13,6 +13,7 @@ const userData = {
 const answerData = {
   id: "answerId1",
   content: "answer1",
+  evaluation: 1,
   questionId: "postId12",
   respondentId: "authorId1",
   updatedAt: new Date(2021, 12, 10, 0, 0, 0),

--- a/tests/api/post.test.js
+++ b/tests/api/post.test.js
@@ -194,6 +194,7 @@ const answerData = [
   {
     id: "answerId1",
     content: "answer1",
+    evaluation: 0,
     questionId: "postId12",
     respondentId: "userId1",
     updatedAt: new Date(2021, 12, 10, 0, 0, 0),
@@ -202,6 +203,7 @@ const answerData = [
   {
     id: "answerId2",
     content: "answer2",
+    evaluation: 1,
     questionId: "postId12",
     respondentId: "userId1",
     updatedAt: new Date(2021, 12, 11, 0, 0, 0),
@@ -598,11 +600,13 @@ describe("postAPIのテスト", () => {
         expect(response.body.answers).toHaveLength(2);
         expect(response.body.answers[0].id).toBe("answerId1");
         expect(response.body.answers[0].content).toBe("answer1");
+        expect(response.body.answers[0].evaluation).toBe(0);
         expect(response.body.answers[0].createdAt).toBe(
           answer1CreatedAt.toISOString()
         );
         expect(response.body.answers[1].id).toBe("answerId2");
         expect(response.body.answers[1].content).toBe("answer2");
+        expect(response.body.answers[1].evaluation).toBe(1);
         expect(response.body.answers[1].createdAt).toBe(
           answer2CreatedAt.toISOString()
         );

--- a/tests/api/user.test.js
+++ b/tests/api/user.test.js
@@ -59,6 +59,7 @@ const answerData = [
   {
     id: "answerId1",
     content: "answer1",
+    evaluation: 0,
     questionId: "postId1",
     respondentId: "userId1",
     createdAt: new Date(2021, 1, 5, 0, 0, 0),
@@ -67,6 +68,7 @@ const answerData = [
   {
     id: "answerId2",
     content: "answer2",
+    evaluation: 1,
     questionId: "postId2",
     respondentId: "userId1",
     createdAt: new Date(2021, 2, 5, 0, 0, 0),
@@ -239,6 +241,9 @@ describe("userAPIのテスト", () => {
         expect(response.body.answers).toHaveLength(2);
         expect(response.body.answers[0].id).toBe(answerData[1].id);
         expect(response.body.answers[0].content).toBe(answerData[1].content);
+        expect(response.body.answers[0].evaluation).toBe(
+          answerData[1].evaluation
+        );
         expect(response.body.answers[0].createdAt).toBe(
           answer2CreatedAt.toISOString()
         );
@@ -247,6 +252,9 @@ describe("userAPIのテスト", () => {
         );
         expect(response.body.answers[1].id).toBe(answerData[0].id);
         expect(response.body.answers[1].content).toBe(answerData[0].content);
+        expect(response.body.answers[1].evaluation).toBe(
+          answerData[0].evaluation
+        );
         expect(response.body.answers[1].createdAt).toBe(
           answer1CreatedAt.toISOString()
         );


### PR DESCRIPTION
## Issue
#98 

## 概要
物件の評価を表すカラムであるevaluationをanswerモデルに追加

以下詳細
- answerモデルにevaluationを追加し、マイグレーションを実行
- コントローラーのanswerモデルのattributesにevaluationを追加
- attributesにevaluationを追加したのでanswerモデルに関連するテストを修正

## 動作確認内容
テストを実行して成功することを確認
![image](https://user-images.githubusercontent.com/83702606/141452091-509a5b50-4080-452c-939d-81ae56837fb9.png)

## 関連リンク
https://github.com/tko-asn/bukken-frontend/pull/121