### PR TITLE
【投稿機能】お気に入りの投稿ランキングのデータを取得する機能を作成

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "scripts": {
     "start": "npx nodemon server",
-    "test": "cross-env NODE_ENV=test npm run db:setup && jest && npm run db:drop",
-    "db:setup": "sequelize db:create && sequelize db:migrate",
+    "test": "npm run db:drop && npm run db:setup && jest $npm_config_pattern",
+    "db:setup": "cross-env NODE_ENV=test sequelize db:create && cross-env NODE_ENV=test sequelize db:migrate",
     "db:drop": "cross-env NODE_ENV=test sequelize db:drop"
   },
   "dependencies": {

--- a/routes/posts.js
+++ b/routes/posts.js
@@ -37,6 +37,13 @@ router.get(
   postController.errorHandling
 );
 
+// お気に入り登録された投稿のランキングを取得
+router.get(
+  "/favorite/post/ranking/:page",
+  postController.getFavoritePostRanking,
+  postController.errorHandling
+);
+
 // 特定の投稿を取得
 router.get(
   "/post/:postId",

--- a/tests/api/post.test.js
+++ b/tests/api/post.test.js
@@ -553,6 +553,55 @@ describe("postAPIのテスト", () => {
     });
   });
 
+  describe("GET /posts/favorite/post/ranking/:page", () => {
+    // お気に入りの投稿データを追加
+    beforeAll(async () => {
+      await db.UserPost.bulkCreate([
+        { postId: "postId10", userId: "userId1" },
+        { postId: "postId10", userId: "userId2" },
+      ]);
+    });
+
+    // 追加したデータを削除
+    afterAll(async () => {
+      await db.UserPost.destroy({ where: { postId: "postId10" } });
+    });
+
+    describe("正常系", () => {
+      it("投稿のカラムが正常に取得できている", async () => {
+        const response = await request(server).get(
+          "/posts/favorite/post/ranking/1"
+        );
+
+        expect(response.statusCode).toBe(200);
+        expect(response.body.total).toBe(1);
+        expect(response.body.posts).toHaveLength(3);
+
+        expect(response.body.posts[0].id).toBe(postData[9].id);
+        expect(response.body.posts[0].title).toBe(postData[9].title);
+        expect(response.body.posts[0].property).toBe(postData[9].property);
+        expect(response.body.posts[0].userCount).toBe(2);
+        expect(response.body.posts[0].updatedAt).toBe(
+          postData[9].updatedAt.toISOString()
+        );
+        expect(response.body.posts[1].id).toBe(postData[11].id);
+        expect(response.body.posts[1].title).toBe(postData[11].title);
+        expect(response.body.posts[1].property).toBe(postData[11].property);
+        expect(response.body.posts[1].userCount).toBe(1);
+        expect(response.body.posts[1].updatedAt).toBe(
+          postData[11].updatedAt.toISOString()
+        );
+        expect(response.body.posts[2].id).toBe(postData[10].id);
+        expect(response.body.posts[2].title).toBe(postData[10].title);
+        expect(response.body.posts[2].property).toBe(postData[10].property);
+        expect(response.body.posts[2].userCount).toBe(1);
+        expect(response.body.posts[2].updatedAt).toBe(
+          postData[10].updatedAt.toISOString()
+        );
+      });
+    });
+  });
+
   describe("GET /posts/post/:postId", () => {
     describe("正常系", () => {
       it("投稿のカラムが取得できている", async () => {


### PR DESCRIPTION
## Issue
#101 

## 概要
お気に入りの投稿ランキングのデータを取得するための機能を作成

以下詳細
- お気に入り投稿ランキング取得機能をpost-controller.jsに追加
- 上記の機能のルートを作成
- テスト実行コマンドの最初にテスト用DBを削除する処理を追加
- お気に入りの投稿ランキング取得用機能のテストを作成

## 動作確認内容
テストを実行して成功することを確認
![image](https://user-images.githubusercontent.com/83702606/145560522-c1cebbe7-5c10-49a3-9403-088be48133de.png)

## 関連リンク
フロントエンドのプルリクエスト
https://github.com/tko-asn/bukken-frontend/pull/141