### PR TITLE
【開発環境】開発環境をDockerへ移行

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ node_modules
 *.njsproj
 *.sln
 *.sw?
+
+Dockerfile
+.dockerignore

--- a/config/config.json
+++ b/config/config.json
@@ -3,14 +3,14 @@
     "username": "dev_admin",
     "password": "dev_admin_pass",
     "database": "yobo_development",
-    "host": "127.0.0.1",
+    "host": "db",
     "dialect": "mysql"
   },
   "test": {
-    "username": "test_admin",
-    "password": "test_admin_pass",
+    "username": "dev_admin",
+    "password": "dev_admin_pass",
     "database": "yobo_test",
-    "host": "127.0.0.1",
+    "host": "db",
     "dialect": "mysql"
   },
   "production": {


### PR DESCRIPTION
## Issue
#103 

## 概要
開発環境をDockerへ移行した

以下詳細
- 開発環境をDockerへと移行したが、Dockerfileと.dockerignoreは開発環境でしか使用しないため、.gitignoreに記述した
-開発時とテスト時で使用するDBを変更できるように ../config/config.jsonの内容を変更
